### PR TITLE
"deadbolt-scala" % "2.5.0"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ scalaVersion := "2.11.7"
 organization := "be.objectify"
 
 libraryDependencies ++= Seq(
-  "be.objectify" %% "deadbolt-scala" % "2.5.0-SNAPSHOT"
+  "be.objectify" %% "deadbolt-scala" % "2.5.0"
 )
 
 routesGenerator := InjectedRoutesGenerator


### PR DESCRIPTION
Fixes deadbolt-scala_2.11;2.5.0-SNAPSHOT: not found #3